### PR TITLE
Sync vendor options to stored data

### DIFF
--- a/custom_components/trackit/store.py
+++ b/custom_components/trackit/store.py
@@ -27,9 +27,13 @@ class TrackItStore:
         if data is None:
             data = {
                 "last_uid": 0,
-                "vendors": self.entry.options.get(CONF_VENDORS, []),
+                "vendors": [],
                 "cache": [],
             }
+        entry_vendors = self.entry.options.get(CONF_VENDORS, [])
+        if data.get("vendors") != entry_vendors:
+            data["vendors"] = entry_vendors
+            await self._store.async_save(data)
         self.data = data
 
     async def async_save(self) -> None:

--- a/tests/components/trackit/test_store.py
+++ b/tests/components/trackit/test_store.py
@@ -1,0 +1,31 @@
+import pytest
+from types import SimpleNamespace
+
+from custom_components.trackit.const import CONF_VENDORS
+from custom_components.trackit.models import VendorConfig
+from custom_components.trackit.store import TrackItStore
+
+
+class FakeStore:
+    def __init__(self, hass, version, key):
+        self.data = {"last_uid": 0, "vendors": [], "cache": []}
+        self.saved = None
+
+    async def async_load(self):
+        return self.data
+
+    async def async_save(self, data):
+        self.saved = data
+        self.data = data
+
+
+@pytest.mark.asyncio
+async def test_async_load_updates_vendors_from_options(monkeypatch):
+    """Ensure options vendors are stored and loaded."""
+    monkeypatch.setattr("custom_components.trackit.store.Store", FakeStore)
+    vendor = VendorConfig(name="DHL", regex=["\\d+"])
+    entry = SimpleNamespace(entry_id="1", options={CONF_VENDORS: [vars(vendor)]})
+    store = TrackItStore(None, entry)
+    await store.async_load()
+    assert store.vendors == [vendor]
+    assert store._store.saved["vendors"] == [vars(vendor)]


### PR DESCRIPTION
## Summary
- ensure store copies vendor options into persistent JSON
- add regression test for persisting vendor options

## Testing
- `pre-commit run --files custom_components/trackit/store.py tests/components/trackit/test_store.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6898b0665c588326aea0811d140ad0ea